### PR TITLE
Fix: Corrected _speed variable size for I2C clock setting to prevent data reception delay.

### DIFF
--- a/src/AtomJoyStick.h
+++ b/src/AtomJoyStick.h
@@ -26,7 +26,7 @@ class AtomJoyStick {
     TwoWire* _wire;
     uint8_t _scl;
     uint8_t _sda;
-    uint8_t _speed;
+    uint32_t _speed;
     void writeBytes(uint8_t addr, uint8_t reg, uint8_t* buffer, uint8_t length);
     void readBytes(uint8_t addr, uint8_t reg, uint8_t* buffer, uint8_t length);
 


### PR DESCRIPTION
The _speed variable for storing the I2C clock setting was previously defined as uint8_t (1 byte), which caused it to incorrectly store the value 128 when set to 400000UL. 

This led to significantly slow data reception from the Atom JoyStick. Changed the variable type to prevent this issue.
