### PR TITLE
Added a sound to notify when long term storage voltage has been reached

### DIFF
--- a/examples/StampFlyController/lib/M5AtomS3/src/M5AtomS3.h
+++ b/examples/StampFlyController/lib/M5AtomS3/src/M5AtomS3.h
@@ -37,6 +37,6 @@ extern M5AtomS3 M5;
 //#define Imu IMU
 
 #else
-#error “This library only supports boards with ESP32 processor.”
+#error "This library only supports boards with ESP32 processor."
 #endif
 #endif

--- a/examples/StampFlyController/platformio.ini
+++ b/examples/StampFlyController/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env]
-platform = espressif32
+platform = espressif32 @ 6.9.0
 board = m5stack-atoms3
 framework = arduino
 board_build.partitions = partitions.csv

--- a/examples/StampFlyController/src/buzzer.cpp
+++ b/examples/StampFlyController/src/buzzer.cpp
@@ -29,6 +29,15 @@ void beep(void) {
     buzzer_sound(4000, 100);
 }
 
+void good_voltage_tone(void) {
+    buzzer_sound(NOTE_D1, 100);
+    buzzer_sound(NOTE_D3, 100);
+    buzzer_sound(NOTE_D5, 100);
+    buzzer_sound(NOTE_D2, 100);
+    buzzer_sound(NOTE_D4, 100);
+    buzzer_sound(NOTE_D6, 100);
+}
+
 void start_tone(void) {
     buzzer_sound(NOTE_D1, 200);
     buzzer_sound(NOTE_D5, 200);

--- a/examples/StampFlyController/src/buzzer.h
+++ b/examples/StampFlyController/src/buzzer.h
@@ -16,6 +16,7 @@
 
 void setup_pwm_buzzer(void);
 void beep(void);
+void good_voltage_tone(void);
 void start_tone(void);
 void buzzer_sound(uint32_t frequency, uint32_t duration_ms);
 

--- a/examples/StampFlyController/src/main.cpp
+++ b/examples/StampFlyController/src/main.cpp
@@ -496,6 +496,24 @@ void loop() {
     uint16_t _theta;     // = getElevator();
     uint16_t _psi;       // = getRudder();
 
+    if (page_nums == PAGE_SETUP)
+    {  // 長期保管に適したバッテリー電圧になったとき通知音を鳴らす
+        static bool prev_good_voltage[2];
+        for (int i = 0; i < 2; ++i) {
+            bool is_nice_voltage = (Battery_voltage[i] > 3.8f && Battery_voltage[i] < 3.9f);
+            bool is_good_voltage = (Battery_voltage[i] > 3.83f && Battery_voltage[i] < 3.87f);
+            if (is_nice_voltage == is_good_voltage) {
+                if (prev_good_voltage[i] != is_good_voltage) {
+                    prev_good_voltage[i] = is_good_voltage;
+                    if (is_good_voltage) {
+                        // 3.85v付近になったら通知音を鳴らす
+                        good_voltage_tone();
+                    }
+                }
+            }
+        }
+    }
+
     while (Loop_flag == 0);
     Loop_flag = 0;
     etime     = stime;


### PR DESCRIPTION
When storing batteries, too high or low voltage can cause failure.
This pull request adds a feature to notify the user with an audible notification when the optimal voltage is reached.